### PR TITLE
CONT-1219 : fail ci for puppetlabs members if no label

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a basic action that will label issues and pull request with a given labe
 | label_color | false | The color of the label. If the label already exists in the repository, this setting will have no effect. | 5319E7 |
 | org_membership | false | Contributions from users that are not members of the specified organisations will be labeled with the configured label. The value can be a single organisation or a comma-separated list of organisations. | puppetlabs |
 | logins_to_ignore | false | Contributions from the specified users will not be labeled by this action. The value can be a single login or a comma-separated list of logins. | `N/A` |
+| fail_if_member | false | Pipeline will fail, if the user is member of specified organisations and no label has been added manually. | false |
 | token | true | A token with enough privilege to view org memberships and repo content. | `N/A` |
 
 ## Security

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -160,13 +160,48 @@ describe('With a new github client', () => {
     )
   })
 
-  test('hasLabel returns true if the label already exists on the issue or pr', () => {
-    const result = client.hasLabel('community')
-    expect(result).toBe(true)
+  test('getLabels returns true if the label already exists on the issue or pr', () => {
+    const result = client.getLabels()
+    expect(result).toEqual(['community'])
+  })
+})
+
+describe('With a new github client without label', () => {
+  let client: GitHubClient
+
+  beforeAll(() => {
+    process.env['GITHUB_PATH'] = ''
+
+    Object.defineProperty(github, 'context', {
+      value: {
+        eventName: 'issues',
+        repo: {
+          owner: 'puppetlabs',
+          repo: 'iac'
+        },
+        issue: {
+          number: 331
+        },
+        payload: {
+          action: 'opened',
+          sender: {
+            login: 'dependabot[bot]'
+          },
+          issue: {
+            labels: [
+            ]
+          }
+        }
+      }
+    })
+
+    client = new GitHubClient('1234')
+    console.log('::stop-commands::stoptoken')
+    process.stdout.write = jest.fn()
   })
 
-  test('hasLabel returns false if the label does not exist on the issue or pr', () => {
-    const result = client.hasLabel('test')
+  test('getLabels returns false if the label does not exist on the issue or pr', () => {
+    const result = client.getLabels()
     expect(result).toBe(false)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   logins_to_ignore:
     description: 'Contributions from the specified users will not be labeled by this action. The value can be a single login or a comma-separated list of logins.'
     required: false
+  fail_if_member:
+    description: 'Pipeline will fail, if the user is member of specified organisations and no label has been added manually.'
+    default: 'false'
+    required: false
   token:
     description: 'The GitHub token to use for authentication.'
     required: true

--- a/src/github.ts
+++ b/src/github.ts
@@ -88,7 +88,7 @@ export class GitHubClient {
   }
 
   // Checks if the issue already has the label
-  hasLabel(name: string): boolean {
+  getLabels(): string[] | false {
     let labels!: Label[]
 
     if (github.context.eventName === 'issues') {
@@ -103,7 +103,11 @@ export class GitHubClient {
       return false
     }
 
-    return labels.some((l) => l.name === name)
+    if (labels.length > 0) {
+      return labels.map((label) => label.name)
+    }
+
+    return false
   }
 
   /* Adds the label to the issue/pull request. It will attempt to create the label


### PR DESCRIPTION
Adding the support for PR's to fail my puppetlabs members if no label is added manually